### PR TITLE
Add English texts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,9 @@
 	"packages": {
 		"": {
 			"name": "cloudnativeday.ch",
+			"dependencies": {
+				"svelte-i18n": "^3.6.0"
+			},
 			"devDependencies": {
 				"@skeletonlabs/skeleton": "^1.1.0",
 				"@sveltejs/adapter-static": "^2.0.0",
@@ -432,6 +435,50 @@
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@formatjs/ecma402-abstract": {
+			"version": "1.11.4",
+			"resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.4.tgz",
+			"integrity": "sha512-EBikYFp2JCdIfGEb5G9dyCkTGDmC57KSHhRQOC3aYxoPWVZvfWCDjZwkGYHN7Lis/fmuWl906bnNTJifDQ3sXw==",
+			"dependencies": {
+				"@formatjs/intl-localematcher": "0.2.25",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@formatjs/fast-memoize": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz",
+			"integrity": "sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@formatjs/icu-messageformat-parser": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.0.tgz",
+			"integrity": "sha512-Qxv/lmCN6hKpBSss2uQ8IROVnta2r9jd3ymUEIjm2UyIkUCHVcbUVRGL/KS/wv7876edvsPe+hjHVJ4z8YuVaw==",
+			"dependencies": {
+				"@formatjs/ecma402-abstract": "1.11.4",
+				"@formatjs/icu-skeleton-parser": "1.3.6",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@formatjs/icu-skeleton-parser": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.6.tgz",
+			"integrity": "sha512-I96mOxvml/YLrwU2Txnd4klA7V8fRhb6JG/4hm3VMNmeJo1F03IpV2L3wWt7EweqNLES59SZ4d6hVOPCSf80Bg==",
+			"dependencies": {
+				"@formatjs/ecma402-abstract": "1.11.4",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@formatjs/intl-localematcher": {
+			"version": "0.2.25",
+			"resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.25.tgz",
+			"integrity": "sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==",
+			"dependencies": {
+				"tslib": "^2.1.0"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
@@ -1135,6 +1182,21 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/cli-color": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.3.tgz",
+			"integrity": "sha512-OkoZnxyC4ERN3zLzZaY9Emb7f/MhBOIpePv0Ycok0fJYT+Ouo00UBEIwsVsr0yoow++n5YWlSUgST9GKhNHiRQ==",
+			"dependencies": {
+				"d": "^1.0.1",
+				"es5-ext": "^0.10.61",
+				"es6-iterator": "^2.0.3",
+				"memoizee": "^0.4.15",
+				"timers-ext": "^0.1.7"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1203,6 +1265,15 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/d": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+			"integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+			"dependencies": {
+				"es5-ext": "^0.10.50",
+				"type": "^1.0.1"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1230,7 +1301,6 @@
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
 			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1292,11 +1362,55 @@
 			"integrity": "sha512-nEftV1dRX3omlxAj42FwqRZT0i4xd2dIg39sog/CnCJeCcL1TRd2Uh0i9Oebgv8Ou0vzTPw++xc+Z20jzS2B6A==",
 			"dev": true
 		},
+		"node_modules/es5-ext": {
+			"version": "0.10.62",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+			"integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.3",
+				"next-tick": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/es6-iterator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+			"dependencies": {
+				"d": "1",
+				"es5-ext": "^0.10.35",
+				"es6-symbol": "^3.1.1"
+			}
+		},
 		"node_modules/es6-promise": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
 			"integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
 			"dev": true
+		},
+		"node_modules/es6-symbol": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+			"integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+			"dependencies": {
+				"d": "^1.0.1",
+				"ext": "^1.1.2"
+			}
+		},
+		"node_modules/es6-weak-map": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+			"integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+			"dependencies": {
+				"d": "1",
+				"es5-ext": "^0.10.46",
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.1"
+			}
 		},
 		"node_modules/esbuild": {
 			"version": "0.17.15",
@@ -1556,6 +1670,11 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1564,6 +1683,28 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/event-emitter": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+			"integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+			"dependencies": {
+				"d": "1",
+				"es5-ext": "~0.10.14"
+			}
+		},
+		"node_modules/ext": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+			"integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+			"dependencies": {
+				"type": "^2.7.2"
+			}
+		},
+		"node_modules/ext/node_modules/type": {
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+			"integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -1768,8 +1909,7 @@
 		"node_modules/globalyzer": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
-			"integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
-			"dev": true
+			"integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
 		},
 		"node_modules/globby": {
 			"version": "11.1.0",
@@ -1794,8 +1934,7 @@
 		"node_modules/globrex": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-			"dev": true
+			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
 		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
@@ -1880,6 +2019,17 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
+		"node_modules/intl-messageformat": {
+			"version": "9.13.0",
+			"resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.13.0.tgz",
+			"integrity": "sha512-7sGC7QnSQGa5LZP7bXLDhVDtQOeKGeBFGHF2Y8LVBwYZoQZCgWeKoPGTa5GMG8g/TzDgeXuYJQis7Ggiw2xTOw==",
+			"dependencies": {
+				"@formatjs/ecma402-abstract": "1.11.4",
+				"@formatjs/fast-memoize": "1.2.1",
+				"@formatjs/icu-messageformat-parser": "2.1.0",
+				"tslib": "^2.1.0"
+			}
+		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1942,6 +2092,11 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/is-promise": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+			"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -2062,6 +2217,14 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/lru-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+			"integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+			"dependencies": {
+				"es5-ext": "~0.10.2"
+			}
+		},
 		"node_modules/magic-string": {
 			"version": "0.30.0",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
@@ -2072,6 +2235,21 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/memoizee": {
+			"version": "0.4.15",
+			"resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
+			"integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+			"dependencies": {
+				"d": "^1.0.1",
+				"es5-ext": "^0.10.53",
+				"es6-weak-map": "^2.0.3",
+				"event-emitter": "^0.3.5",
+				"is-promise": "^2.2.2",
+				"lru-queue": "^0.1.0",
+				"next-tick": "^1.1.0",
+				"timers-ext": "^0.1.7"
 			}
 		},
 		"node_modules/merge2": {
@@ -2154,7 +2332,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
 			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -2214,6 +2391,11 @@
 			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
 			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
 			"dev": true
+		},
+		"node_modules/next-tick": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.10",
@@ -2720,7 +2902,6 @@
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
 			"integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
-			"dev": true,
 			"dependencies": {
 				"mri": "^1.1.0"
 			},
@@ -2955,7 +3136,6 @@
 			"version": "3.58.0",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.58.0.tgz",
 			"integrity": "sha512-brIBNNB76mXFmU/Kerm4wFnkskBbluBDCjx/8TcpYRb298Yh2dztS2kQ6bhtjMcvUhd5ynClfwpz5h2gnzdQ1A==",
-			"dev": true,
 			"engines": {
 				"node": ">= 8"
 			}
@@ -2992,6 +3172,28 @@
 			},
 			"peerDependencies": {
 				"svelte": ">=3.19.0"
+			}
+		},
+		"node_modules/svelte-i18n": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/svelte-i18n/-/svelte-i18n-3.6.0.tgz",
+			"integrity": "sha512-qvvcMqHVCXJ5pHoQR5uGzWAW5vS3qB9mBq+W6veLZ6jkrzZGOziR+wyOUJsc59BupMh+Ae30qjOndFrRU6v5jA==",
+			"dependencies": {
+				"cli-color": "^2.0.3",
+				"deepmerge": "^4.2.2",
+				"estree-walker": "^2",
+				"intl-messageformat": "^9.13.0",
+				"sade": "^1.8.1",
+				"tiny-glob": "^0.2.9"
+			},
+			"bin": {
+				"svelte-i18n": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"peerDependencies": {
+				"svelte": "^3.25.1"
 			}
 		},
 		"node_modules/svelte-preprocess": {
@@ -3137,11 +3339,19 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/timers-ext": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+			"integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+			"dependencies": {
+				"es5-ext": "~0.10.46",
+				"next-tick": "1"
+			}
+		},
 		"node_modules/tiny-glob": {
 			"version": "0.2.9",
 			"resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
 			"integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
-			"dev": true,
 			"dependencies": {
 				"globalyzer": "0.1.0",
 				"globrex": "^0.1.2"
@@ -3177,8 +3387,7 @@
 		"node_modules/tslib": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-			"dev": true
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
 		},
 		"node_modules/tsutils": {
 			"version": "3.21.0",
@@ -3200,6 +3409,11 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
+		},
+		"node_modules/type": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -3604,6 +3818,50 @@
 			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.38.0.tgz",
 			"integrity": "sha512-IoD2MfUnOV58ghIHCiil01PcohxjbYR/qCxsoC+xNgUwh1EY8jOOrYmu3d3a71+tJJ23uscEV4X2HJWMsPJu4g==",
 			"dev": true
+		},
+		"@formatjs/ecma402-abstract": {
+			"version": "1.11.4",
+			"resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.4.tgz",
+			"integrity": "sha512-EBikYFp2JCdIfGEb5G9dyCkTGDmC57KSHhRQOC3aYxoPWVZvfWCDjZwkGYHN7Lis/fmuWl906bnNTJifDQ3sXw==",
+			"requires": {
+				"@formatjs/intl-localematcher": "0.2.25",
+				"tslib": "^2.1.0"
+			}
+		},
+		"@formatjs/fast-memoize": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz",
+			"integrity": "sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==",
+			"requires": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"@formatjs/icu-messageformat-parser": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.0.tgz",
+			"integrity": "sha512-Qxv/lmCN6hKpBSss2uQ8IROVnta2r9jd3ymUEIjm2UyIkUCHVcbUVRGL/KS/wv7876edvsPe+hjHVJ4z8YuVaw==",
+			"requires": {
+				"@formatjs/ecma402-abstract": "1.11.4",
+				"@formatjs/icu-skeleton-parser": "1.3.6",
+				"tslib": "^2.1.0"
+			}
+		},
+		"@formatjs/icu-skeleton-parser": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.6.tgz",
+			"integrity": "sha512-I96mOxvml/YLrwU2Txnd4klA7V8fRhb6JG/4hm3VMNmeJo1F03IpV2L3wWt7EweqNLES59SZ4d6hVOPCSf80Bg==",
+			"requires": {
+				"@formatjs/ecma402-abstract": "1.11.4",
+				"tslib": "^2.1.0"
+			}
+		},
+		"@formatjs/intl-localematcher": {
+			"version": "0.2.25",
+			"resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.25.tgz",
+			"integrity": "sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==",
+			"requires": {
+				"tslib": "^2.1.0"
+			}
 		},
 		"@humanwhocodes/config-array": {
 			"version": "0.11.8",
@@ -4065,6 +4323,18 @@
 				}
 			}
 		},
+		"cli-color": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.3.tgz",
+			"integrity": "sha512-OkoZnxyC4ERN3zLzZaY9Emb7f/MhBOIpePv0Ycok0fJYT+Ouo00UBEIwsVsr0yoow++n5YWlSUgST9GKhNHiRQ==",
+			"requires": {
+				"d": "^1.0.1",
+				"es5-ext": "^0.10.61",
+				"es6-iterator": "^2.0.3",
+				"memoizee": "^0.4.15",
+				"timers-ext": "^0.1.7"
+			}
+		},
 		"color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4115,6 +4385,15 @@
 			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
 			"dev": true
 		},
+		"d": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+			"integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+			"requires": {
+				"es5-ext": "^0.10.50",
+				"type": "^1.0.1"
+			}
+		},
 		"debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -4133,8 +4412,7 @@
 		"deepmerge": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-			"dev": true
+			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
 		},
 		"detect-indent": {
 			"version": "6.1.0",
@@ -4184,11 +4462,51 @@
 			"integrity": "sha512-nEftV1dRX3omlxAj42FwqRZT0i4xd2dIg39sog/CnCJeCcL1TRd2Uh0i9Oebgv8Ou0vzTPw++xc+Z20jzS2B6A==",
 			"dev": true
 		},
+		"es5-ext": {
+			"version": "0.10.62",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+			"integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+			"requires": {
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.3",
+				"next-tick": "^1.1.0"
+			}
+		},
+		"es6-iterator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+			"requires": {
+				"d": "1",
+				"es5-ext": "^0.10.35",
+				"es6-symbol": "^3.1.1"
+			}
+		},
 		"es6-promise": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
 			"integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
 			"dev": true
+		},
+		"es6-symbol": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+			"integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+			"requires": {
+				"d": "^1.0.1",
+				"ext": "^1.1.2"
+			}
+		},
+		"es6-weak-map": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+			"integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+			"requires": {
+				"d": "1",
+				"es5-ext": "^0.10.46",
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.1"
+			}
 		},
 		"esbuild": {
 			"version": "0.17.15",
@@ -4385,11 +4703,40 @@
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true
 		},
+		"estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+		},
 		"esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
+		},
+		"event-emitter": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+			"integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+			"requires": {
+				"d": "1",
+				"es5-ext": "~0.10.14"
+			}
+		},
+		"ext": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+			"integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+			"requires": {
+				"type": "^2.7.2"
+			},
+			"dependencies": {
+				"type": {
+					"version": "2.7.2",
+					"resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+					"integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
+				}
+			}
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -4546,8 +4893,7 @@
 		"globalyzer": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
-			"integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
-			"dev": true
+			"integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
 		},
 		"globby": {
 			"version": "11.1.0",
@@ -4566,8 +4912,7 @@
 		"globrex": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-			"dev": true
+			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
 		},
 		"graceful-fs": {
 			"version": "4.2.11",
@@ -4634,6 +4979,17 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
+		"intl-messageformat": {
+			"version": "9.13.0",
+			"resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.13.0.tgz",
+			"integrity": "sha512-7sGC7QnSQGa5LZP7bXLDhVDtQOeKGeBFGHF2Y8LVBwYZoQZCgWeKoPGTa5GMG8g/TzDgeXuYJQis7Ggiw2xTOw==",
+			"requires": {
+				"@formatjs/ecma402-abstract": "1.11.4",
+				"@formatjs/fast-memoize": "1.2.1",
+				"@formatjs/icu-messageformat-parser": "2.1.0",
+				"tslib": "^2.1.0"
+			}
+		},
 		"is-binary-path": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -4678,6 +5034,11 @@
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true
+		},
+		"is-promise": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+			"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -4770,6 +5131,14 @@
 				"yallist": "^4.0.0"
 			}
 		},
+		"lru-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+			"integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+			"requires": {
+				"es5-ext": "~0.10.2"
+			}
+		},
 		"magic-string": {
 			"version": "0.30.0",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
@@ -4777,6 +5146,21 @@
 			"dev": true,
 			"requires": {
 				"@jridgewell/sourcemap-codec": "^1.4.13"
+			}
+		},
+		"memoizee": {
+			"version": "0.4.15",
+			"resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
+			"integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+			"requires": {
+				"d": "^1.0.1",
+				"es5-ext": "^0.10.53",
+				"es6-weak-map": "^2.0.3",
+				"event-emitter": "^0.3.5",
+				"is-promise": "^2.2.2",
+				"lru-queue": "^0.1.0",
+				"next-tick": "^1.1.0",
+				"timers-ext": "^0.1.7"
 			}
 		},
 		"merge2": {
@@ -4834,8 +5218,7 @@
 		"mri": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-			"dev": true
+			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
 		},
 		"mrmime": {
 			"version": "1.0.1",
@@ -4877,6 +5260,11 @@
 			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
 			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
 			"dev": true
+		},
+		"next-tick": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
 		},
 		"node-releases": {
 			"version": "2.0.10",
@@ -5187,7 +5575,6 @@
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
 			"integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
-			"dev": true,
 			"requires": {
 				"mri": "^1.1.0"
 			}
@@ -5358,8 +5745,7 @@
 		"svelte": {
 			"version": "3.58.0",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.58.0.tgz",
-			"integrity": "sha512-brIBNNB76mXFmU/Kerm4wFnkskBbluBDCjx/8TcpYRb298Yh2dztS2kQ6bhtjMcvUhd5ynClfwpz5h2gnzdQ1A==",
-			"dev": true
+			"integrity": "sha512-brIBNNB76mXFmU/Kerm4wFnkskBbluBDCjx/8TcpYRb298Yh2dztS2kQ6bhtjMcvUhd5ynClfwpz5h2gnzdQ1A=="
 		},
 		"svelte-check": {
 			"version": "3.2.0",
@@ -5383,6 +5769,19 @@
 			"integrity": "sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==",
 			"dev": true,
 			"requires": {}
+		},
+		"svelte-i18n": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/svelte-i18n/-/svelte-i18n-3.6.0.tgz",
+			"integrity": "sha512-qvvcMqHVCXJ5pHoQR5uGzWAW5vS3qB9mBq+W6veLZ6jkrzZGOziR+wyOUJsc59BupMh+Ae30qjOndFrRU6v5jA==",
+			"requires": {
+				"cli-color": "^2.0.3",
+				"deepmerge": "^4.2.2",
+				"estree-walker": "^2",
+				"intl-messageformat": "^9.13.0",
+				"sade": "^1.8.1",
+				"tiny-glob": "^0.2.9"
+			}
 		},
 		"svelte-preprocess": {
 			"version": "5.0.3",
@@ -5464,11 +5863,19 @@
 				"thenify": ">= 3.1.0 < 4"
 			}
 		},
+		"timers-ext": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+			"integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+			"requires": {
+				"es5-ext": "~0.10.46",
+				"next-tick": "1"
+			}
+		},
 		"tiny-glob": {
 			"version": "0.2.9",
 			"resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
 			"integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
-			"dev": true,
 			"requires": {
 				"globalyzer": "0.1.0",
 				"globrex": "^0.1.2"
@@ -5498,8 +5905,7 @@
 		"tslib": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-			"dev": true
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
 		},
 		"tsutils": {
 			"version": "3.21.0",
@@ -5517,6 +5923,11 @@
 					"dev": true
 				}
 			}
+		},
+		"type": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
 		},
 		"type-check": {
 			"version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"prettier-plugin-svelte": "^2.8.1",
 		"svelte": "^3.54.0",
 		"svelte-check": "^3.0.1",
+		"svelte-i18n": "^3.6.0",
 		"tailwindcss": "^3.3.1",
 		"tslib": "^2.4.1",
 		"typescript": "^5.0.0",

--- a/src/lib/locales/de.json
+++ b/src/lib/locales/de.json
@@ -1,0 +1,64 @@
+{
+	"navigation": {
+		"altMountain": "Berg",
+		"callForSpeakers": "Call for Speakers",
+		"tickets": "Tickets",
+		"location": "Location",
+		"speakers": "Speaker*innen",
+		"sponsors": "Sponsor*innen"
+	},
+	"callForSpeakers": {
+		"title": "Wir Suchen Dich",
+		"body": "Wir suchen suchen nach spannenden Talks und interessanten Speaker*innen. Hast du ein Thema, das die Community interessiert? Melde dich bis am <strong>30. April</strong> und sende uns dein Proposal.",
+		"apply": "Als Speaker*in bewerben"
+	},
+	"description": {
+		"title": "Chum ufe Gurte!",
+		"body": "Im 2023 wird die lokale Cloud Native Community die dritte Ausgabe des Cloud Native Day auf dem Gurten organisieren. Als Organisator*innen sind wir überzeugt, dass die CNCF die wichtigsten Antworten für die Zukunft der IT bereithält. Unser Anlass soll eine Gemeinschaft zusammenbringen, welche sich gegenseitig inspiriert, unterstützt und herausfordert, indem verschiedenste Perspektiven und Erfahrungen zusammenkommen."
+	},
+	"hero": {
+		"altLogo": "Logo",
+		"title": "20. - 21. September | Bern, Schweiz"
+	},
+	"location": {
+		"altPavillon": "Gurten Pavillon",
+		"title": "Location",
+		"body": "Der Cloud Native Day findet auf dem Berner Hausberg, dem Gurten statt. Am einfachsten erreichst Du die Konferenz mit den öffentlichen Verkehrsmitteln.",
+		"directions": {
+			"tram": "Vom Berner HB, mit dem 9ni-Tram (Richtung Wabern) benötigst Du ca. 15 min zur Station «Wabern Gurtenbahn»",
+			"walk": "Von dort ist es ein 5 min Spaziergang zur Gurtenbahn.",
+			"ticket": "Das Gurtenbahn-Ticket ist im Konferenzticket enthalten."
+		}
+	},
+	"perks": {
+		"community": {
+			"title": "Community",
+			"text": "Von Engineers für Engineers, der dritte Schweizer Cloud Native Community Day. Hinter dem Anlass steht der Non-Profit Verein «bernerit.rocks»."
+		},
+		"handsOn": {
+			"title": "Get your Hands Dirty!",
+			"text": "Erfahrung aus der Praxis, Know-how von Hands-On Spezialist*innen und die Möglichkeit mittels Workshops selber Hand anzulegen."
+		},
+		"gurten": {
+			"title": "Gurten",
+			"text": "Ein Tag, 250 Teilnehmende, auf dem einmaligen Berner Hausberg. Aus der Region für die Region."
+		}
+	},
+	"speakers": {
+		"title": "Speaker*innen"
+	},
+	"sponsors": {
+		"title": "Sponsor*innen",
+		"body": "Der Non-Profit Verein «bernerit.rocks» organisiert den Anlass für Cloud Native Praktiker*innen und setzt dabei auf Sponsor*innen. Durch Ihre Unterstützung präsentieren Sie sich an vorderster Front der extrem stark wachsenden Cloud Native Community der Schweiz. Werden Sie Sponsor*in und knüpfen Sie Kontakte mit den anwesenden Spezialist*innen am Cloud Native Day! Bitte nehmen Sie via <a href=\"mailto:sponsoring@cloudnativeday.ch\">sponsoring@cloudnativeday.ch</a> Kontakt mit uns auf.",
+		"tiers": {
+			"gold": "Gold",
+			"speakerEvent": "Speaker Event",
+			"afterParty": "After Party",
+			"silver": "Silver",
+			"bronze": "Bronze"
+		}
+	},
+	"tickets": {
+		"title": "Hol Dir Jetzt Dein Ticket"
+	}
+}

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -1,0 +1,64 @@
+{
+	"navigation": {
+		"altMountain": "Mountain",
+		"callForSpeakers": "Call for Speakers",
+		"tickets": "Tickets",
+		"location": "Location",
+		"speakers": "Speakers",
+		"sponsors": "Sponsors"
+	},
+	"callForSpeakers": {
+		"title": "We are Looking for You",
+		"body": "We are looking for captivating talks and interesting speakers. Do you have a topic of interest to the community? Then please get in touch and submit your proposal by <strong>April 30</strong>",
+		"apply": "Apply as a Speaker"
+	},
+	"description": {
+		"title": "See you on the Gurten!",
+		"body": "In 2023, the local Cloud Native community will organize the third edition of the Swiss Cloud Native Day on Mount Gurten. As organizers, we are convinced that the CNCF is providing the most important answers for the future of IT. Our event will bring newcomers and experts together and be an inspirational place where different perspectives and experiences meet."
+	},
+	"hero": {
+		"altLogo": "Logo",
+		"title": "September 20 - 21 | Bern, Switzerland"
+	},
+	"location": {
+		"altPavillon": "Gurten Pavillon",
+		"title": "Venue",
+		"body": "The Cloud Native Day takes place on Mount Gurten close to the City of Bern. Easy access via public transport.",
+		"directions": {
+			"tram": "Starting from Bern main station, take tram no. 9 (direction Wabern) until station “Wabern Gurtenbahn”. Travel time is about 15 minutes",
+			"walk": "Walk 5 minutes to the lower terminal of the Gurtenbahn funicular railway.",
+			"ticket": "Show your conference ticket and enjoy a free ride on the funicular."
+		}
+	},
+	"perks": {
+		"community": {
+			"title": "Community",
+			"text": "From engineers, for engineers—the first Swiss Cloud Native Community Day. Organized by the Swiss nonprofit association “bernerit.rocks”."
+		},
+		"handsOn": {
+			"title": "Get your Hands Dirty!",
+			"text": "Practical expertise from seasoned, hands-on specialists who will share their knowledge in three-hour workshops."
+		},
+		"gurten": {
+			"title": "Mount Gurten",
+			"text": "One day, 250 participants, atop Bern‘s lovely Mount Gurten."
+		}
+	},
+	"speakers": {
+		"title": "Speakers"
+	},
+	"sponsors": {
+		"title": "Sponsors",
+		"body": "The nonprofit association “bernerit.rocks” organizes this event for Cloud Native practitioners with the help of lots of voluntary work and of course sponsors. With a sponsorship, you can present yourself prominently in front of this extremely fast growing Swiss Cloud Native Community. Become a sponsor and get in contact with the Cloud Native specialists at the first Swiss Cloud Native Day! Please contact <a href=\"mailto:sponsoring@cloudnativeday.ch\">sponsoring@cloudnativeday.ch</a>.",
+		"tiers": {
+			"gold": "Gold",
+			"speakerEvent": "Speaker Event",
+			"afterParty": "After Party",
+			"silver": "Silver",
+			"bronze": "Bronze"
+		}
+	},
+	"tickets": {
+		"title": "Get your ticket now"
+	}
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,6 +4,17 @@
 	import '../app.postcss';
 	import { AppShell, AppBar } from '@skeletonlabs/skeleton';
 	import mountain from '$lib/images/mountain.svg';
+	import { addMessages, init, getLocaleFromQueryString, _ } from 'svelte-i18n';
+	import en from '$lib/locales/en.json';
+	import de from '$lib/locales/de.json';
+
+	addMessages('en-US', en);
+	addMessages('de-CH', de);
+
+	init({
+		fallbackLocale: 'en-US',
+		initialLocale: getLocaleFromQueryString('lang')
+	});
 </script>
 
 <AppShell>
@@ -11,15 +22,15 @@
 		<AppBar>
 			<svelte:fragment slot="lead">
 				<a href="/">
-					<img src={mountain} alt="Mountain" />
+					<img src={mountain} alt={$_('navigation.altMountain')} />
 				</a>
 			</svelte:fragment>
 			<svelte:fragment slot="trail">
-				<a class="btn variant-ghost-primary" href="#cfp">Call for Speakers</a>
-				<a class="btn variant-ghost-primary" href="#tickets">Tickets</a>
-				<a class="btn variant-ghost-primary" href="#location">Location</a>
-				<a class="btn variant-ghost-primary" href="#speakers">Speaker*innen</a>
-				<a class="btn variant-ghost-primary" href="#sponsors">Sponsor*innen</a>
+				<a class="btn variant-ghost-primary" href="#cfp">{$_('navigation.callForSpeakers')}</a>
+				<a class="btn variant-ghost-primary" href="#tickets">{$_('navigation.tickets')}</a>
+				<a class="btn variant-ghost-primary" href="#location">{$_('navigation.location')}</a>
+				<a class="btn variant-ghost-primary" href="#speakers">{$_('navigation.speakers')}</a>
+				<a class="btn variant-ghost-primary" href="#sponsors">{$_('navigation.sponsors')}</a>
 			</svelte:fragment>
 		</AppBar>
 	</svelte:fragment>

--- a/src/routes/CallForSpeakers.svelte
+++ b/src/routes/CallForSpeakers.svelte
@@ -1,12 +1,14 @@
+<script lang="ts">
+	import { _ } from 'svelte-i18n';
+</script>
+
 <div class="w-full px-8 py-28">
 	<div id="cfp" class="container mx-auto flex flex-col items-center max-w-5xl">
-		<h2 class="mb-8">Wir Suchen Dich</h2>
+		<h2 class="mb-8">{$_('callForSpeakers.title')}</h2>
 
 		<div class="prose text-2xl mb-16">
 			<p>
-				Wir suchen suchen nach spannenden Talks und interessanten Speaker*innen. Hast du ein Thema,
-				das die Community interessiert? Melde dich bis am <strong>30. April</strong> und sende uns dein
-				Proposal.
+				{@html $_('callForSpeakers.body')}
 			</p>
 		</div>
 
@@ -16,7 +18,7 @@
 			target="_blank"
 			rel="noopener"
 		>
-			Als Speaker*in Bewerben
+			{$_('callForSpeakers.apply')}
 		</a>
 	</div>
 </div>

--- a/src/routes/Description.svelte
+++ b/src/routes/Description.svelte
@@ -1,14 +1,14 @@
+<script lang="ts">
+	import { _ } from 'svelte-i18n';
+</script>
+
 <div class="bg-slate-100 w-full px-8 py-28">
 	<div id="tickets" class="container mx-auto flex flex-col items-center text-center max-w-5xl">
-		<h2 class="mb-8">Chum ufe Gurte!</h2>
+		<h2 class="mb-8">{$_('description.title')}</h2>
 
 		<div class="prose text-2xl text-left">
 			<p>
-				Im 2023 wird die lokale Cloud Native Community die dritte Ausgabe des Cloud Native Day auf
-				dem Gurten organisieren. Als Organisator*innen sind wir überzeugt, dass die CNCF die
-				wichtigsten Antworten für die Zukunft der IT bereithält. Unser Anlass soll eine Gemeinschaft
-				zusammenbringen, welche sich gegenseitig inspiriert, unterstützt und herausfordert, indem
-				verschiedenste Perspektiven und Erfahrungen zusammenkommen.
+				{$_('description.body')}
 			</p>
 		</div>
 	</div>

--- a/src/routes/Hero.svelte
+++ b/src/routes/Hero.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
 	import logo from '$lib/images/logo.svg';
+	import { _ } from 'svelte-i18n';
 </script>
 
 <div class="container h-screen mx-auto flex justify-center items-center">
 	<div class="space-y-10 text-center">
 		<figure>
 			<div class="img-bg" />
-			<img src={logo} alt="Logo" />
+			<img src={logo} alt={$_('hero.altLogo')} />
 		</figure>
-		<h1 class="font-bold">20. - 21. September | Bern, Switzerland</h1>
+		<h1 class="font-bold">{$_('hero.title')}</h1>
 	</div>
 </div>
 

--- a/src/routes/Location.svelte
+++ b/src/routes/Location.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import pavillon from '$lib/images/gurten-pavillon.jpg';
+	import { _ } from 'svelte-i18n';
 </script>
 
 <div class="w-full px-8 py-28">
@@ -9,24 +10,20 @@
 	>
 		<div class="card">
 			<header>
-				<img src={pavillon} alt="Gurten Pavillon" />
+				<img src={pavillon} alt={$_('location.altPavillon')} />
 			</header>
 			<section class="p-8">
-				<h2 class="text-lg mb-8">Location</h2>
+				<h2 class="text-lg mb-8">{$_('location.title')}</h2>
 				<div class="prose text-lg text-left">
 					<p>
-						Der Cloud Native Day findet auf dem Berner Hausberg, dem Gurten statt. Am einfachsten
-						erreichst Du die Konferenz mit den öffentlichen Verkehrsmitteln.
+						{$_('location.body')}
 					</p>
 
 					<br />
 					<ul class="list-disc list-inside">
-						<li>
-							Vom Berner HB, mit dem 9ni-Tram (Richtung Wabern) benötigst Du ca. 15 min zur Station
-							«Wabern Gurtenbahn»
-						</li>
-						<li>Von dort ist es ein 5 min Spaziergang zur Gurtenbahn.</li>
-						<li>Das Gurtenbahn-Ticket ist im Konferenzticket enthalten.</li>
+						<li>{$_('location.directions.tram')}</li>
+						<li>{$_('location.directions.walk')}</li>
+						<li>{$_('location.directions.ticket')}</li>
 					</ul>
 				</div>
 			</section>

--- a/src/routes/Perks.svelte
+++ b/src/routes/Perks.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	interface Perk {
 		title: string;
 		text: string;
@@ -6,16 +7,16 @@
 
 	const perks: Perk[] = [
 		{
-			title: 'Community',
-			text: 'Von Engineers für Engineers, der dritte Schweizer Cloud Native Community Day. Hinter dem Anlass steht der Non-Profit Verein «bernerit.rocks».'
+			title: $_('perks.community.title'),
+			text: $_('perks.community.text')
 		},
 		{
-			title: 'Get your Hands Dirty!',
-			text: 'Erfahrung aus der Praxis, Know-how von Hands-On Spezialist*innen und die Möglichkeit mittels Workshops selber Hand anzulegen.'
+			title: $_('perks.handsOn.title'),
+			text: $_('perks.handsOn.text')
 		},
 		{
-			title: 'Gurten',
-			text: 'Ein Tag, 250 Teilnehmende, auf dem einmaligen Berner Hausberg. Aus der Region für die Region.'
+			title: $_('perks.gurten.title'),
+			text: $_('perks.gurten.text')
 		}
 	];
 </script>

--- a/src/routes/Speakers.svelte
+++ b/src/routes/Speakers.svelte
@@ -3,6 +3,7 @@
 	import anaisUrlichs from '$lib/images/speakers/anais-urlichs.png';
 	import margaManterola from '$lib/images/speakers/marga-manterola.jpeg';
 	import naomiBrockwell from '$lib/images/speakers/naomi-brockwell.webp';
+	import { _ } from 'svelte-i18n';
 
 	interface Speaker {
 		name: string;
@@ -31,7 +32,7 @@
 
 <div class="bg-slate-100 w-full px-8 py-28">
 	<div id="speakers" class="container mx-auto flex flex-col items-center text-center max-w-5xl">
-		<h2 class="mb-16">Speaker*innen</h2>
+		<h2 class="mb-16">{$_('speakers.title')}</h2>
 
 		<div class="grid md:grid-cols-4 gap-16">
 			{#each speakers as speaker (speaker.name)}

--- a/src/routes/Sponsors.svelte
+++ b/src/routes/Sponsors.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import dieMobiliar from '$lib/images/sponsors/diemobiliar.svg';
 	import amanox from '$lib/images/sponsors/amanox.svg';
 	import avega from '$lib/images/sponsors/avega.png';
@@ -139,22 +140,16 @@
 
 <div class="w-full px-8 py-28">
 	<div id="sponsors" class="container mx-auto flex flex-col items-center text-center max-w-5xl">
-		<h2 class="mb-8">Sponsor*innen</h2>
+		<h2 class="mb-8">{$_('sponsors.title')}</h2>
 
 		<div class="prose text-2xl text-left">
 			<p>
-				Der Non-Profit Verein «bernerit.rocks» organisiert den Anlass für Cloud Native
-				Praktiker*innen und setzt dabei auf Sponsor*innen. Durch Ihre Unterstützung präsentieren Sie
-				sich an vorderster Front der extrem stark wachsenden Cloud Native Community der Schweiz.
-				Werden Sie Sponsor*in und knüpfen Sie Kontakte mit den anwesenden Spezialist*innen am Cloud
-				Native Day! Bitte nehmen Sie via
-				<a href="mailto:sponsoring@cloudnativeday.ch">sponsoring@cloudnativeday.ch</a>
-				Kontakt mit uns auf.
+				{@html $_('sponsors.body')}
 			</p>
 		</div>
 
 		{#if goldSponsors.length > 0}
-			<h3 class="mt-24 w-full text-left">Gold</h3>
+			<h3 class="mt-24 w-full text-left">{$_('sponsors.tiers.gold')}</h3>
 			<div class="grid md:grid-cols-3 items-center">
 				{#each goldSponsors as sponsor (sponsor.name)}
 					<a href={sponsor.link} target="_blank" rel="noopener" class="m-4">
@@ -167,7 +162,7 @@
 		{/if}
 
 		{#if speakerEventSponsors.length > 0}
-			<h3 class="mt-24 w-full text-left">Speaker Event</h3>
+			<h3 class="mt-24 w-full text-left">{$_('sponsors.tiers.speakerEvent')}</h3>
 			<div class="grid md:grid-cols-3 items-center">
 				{#each speakerEventSponsors as sponsor (sponsor.name)}
 					<a href={sponsor.link} target="_blank" rel="noopener" class="m-4">
@@ -180,7 +175,7 @@
 		{/if}
 
 		{#if afterPartySponsors.length > 0}
-			<h3 class="mt-24 w-full text-left">After Party</h3>
+			<h3 class="mt-24 w-full text-left">{$_('sponsors.tiers.afterParty')}</h3>
 			<div class="grid md:grid-cols-3 items-center">
 				{#each afterPartySponsors as sponsor (sponsor.name)}
 					<a href={sponsor.link} target="_blank" rel="noopener" class="m-4">
@@ -193,7 +188,7 @@
 		{/if}
 
 		{#if silverSponsors.length > 0}
-			<h3 class="mt-24 w-full text-left">Silver</h3>
+			<h3 class="mt-24 w-full text-left">{$_('sponsors.tiers.silver')}</h3>
 			<div class="grid md:grid-cols-4 items-center">
 				{#each silverSponsors as sponsor (sponsor.name)}
 					<a href={sponsor.link} target="_blank" rel="noopener" class="m-4">
@@ -206,7 +201,7 @@
 		{/if}
 
 		{#if bronzeSponsors.length > 0}
-			<h3 class="mt-24 w-full text-left">Bronze</h3>
+			<h3 class="mt-24 w-full text-left">{$_('sponsors.tiers.bronze')}</h3>
 			<div class="grid md:grid-cols-6 items-center">
 				{#each bronzeSponsors as sponsor (sponsor.name)}
 					<a href={sponsor.link} target="_blank" rel="noopener" class="m-4">

--- a/src/routes/Tickets.svelte
+++ b/src/routes/Tickets.svelte
@@ -1,10 +1,14 @@
+<script lang="ts">
+	import { _ } from 'svelte-i18n';
+</script>
+
 <svelte:head>
 	<script src="https://js.tito.io/v2" async></script>
 </svelte:head>
 
 <div class="bg-slate-100 w-full px-8 py-28">
 	<section id="tickets" class="container mx-auto flex flex-col items-center max-w-5xl">
-		<h2 class="mb-16">Hol Dir Jetzt Dein Ticket</h2>
+		<h2 class="mb-16">{$_('tickets.title')}</h2>
 		<tito-widget event="berner-it-rocks/swiss-cloud-native-day-2023" />
 	</section>
 </div>


### PR DESCRIPTION
I have added `svelte-i18n` and translations for `en-US` and `de-DE`. I did not include a language chooser yet, since this can be done in a separate step. We can test using the url query parameter `lang=(de-CH|en-US)` for now.

Fixes #3 