### PR TITLE
load tito script synchronously

### DIFF
--- a/src/routes/Tickets.svelte
+++ b/src/routes/Tickets.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <svelte:head>
-	<script src="https://js.tito.io/v2" async></script>
+	<script src="https://js.tito.io/v2"></script>
 </svelte:head>
 
 <div class="bg-slate-100 w-full px-8 py-28">


### PR DESCRIPTION
My hypothesis when tracking down the tito ticket
widget issue is that the async loading of the
script breaks the widget depending on the loading
order of the assets.