### PR TITLE
Initialize the Tito Widget after everything else has loaded

### DIFF
--- a/src/routes/Tickets.svelte
+++ b/src/routes/Tickets.svelte
@@ -1,14 +1,24 @@
 <script lang="ts">
 	import { _ } from 'svelte-i18n';
+
+
 </script>
 
 <svelte:head>
-	<script src="https://js.tito.io/v2" async></script>
+	<script src="https://js.tito.io/v2/with/development_mode" async></script>
+	<script>
+		console.log("hello")
+		window.tito = window.tito || function() { (tito.q = tito.q || []).push(arguments);};
+		setTimeout(function(){
+			tito("widget.mount", {event: "berner-it-rocks/swiss-cloud-native-day-2023", el: "#tito"})
+		}, 500)
+		
+	</script>
 </svelte:head>
 
 <div class="bg-slate-100 w-full px-8 py-28">
 	<section id="tickets" class="container mx-auto flex flex-col items-center max-w-5xl">
 		<h2 class="mb-16">{$_('tickets.title')}</h2>
-		<tito-widget event="berner-it-rocks/swiss-cloud-native-day-2023" />
+		<div id="tito"></div>
 	</section>
 </div>


### PR DESCRIPTION
This commit does two things:

1) Uses the JS API to mount the widget rather than the custom component 2) Waits for 1s before mounting the widget

The wait gives the rest of the page time to load before loading the widget.

Better would be to do this on some kind of callback or event when the rest of the page is still building.

OR figuring out what part of that is causing the page to be over-written after the widget is mounted.

But this hack will probably work 99% of the time.