### PR TITLE
Change speaker layout to fix iPhone Safari rendering

### DIFF
--- a/src/routes/Speakers.svelte
+++ b/src/routes/Speakers.svelte
@@ -35,9 +35,8 @@
 </script>
 
 <div class="bg-slate-100 w-full px-8 py-28">
-	<div id="speakers" class="container mx-auto flex flex-col items-center text-center max-w-5xl">
+	<div id="speakers" class="container mx-auto items-center text-center max-w-5xl">
 		<h2 class="mb-16">{$_('speakers.title')}</h2>
-
 		<div class="grid md:grid-cols-4 gap-16">
 			{#each speakers as speaker (speaker.name)}
 				<div class="flex flex-col">

--- a/src/routes/Sponsors.svelte
+++ b/src/routes/Sponsors.svelte
@@ -155,7 +155,7 @@
 </script>
 
 <div class="w-full px-8 py-28">
-	<div id="sponsors" class="container mx-auto flex flex-col items-center text-center max-w-5xl">
+	<div id="sponsors" class="container mx-auto items-center text-center max-w-5xl">
 		<h2 class="mb-8">{$_('sponsors.title')}</h2>
 
 		<div class="prose text-2xl text-left">
@@ -166,7 +166,7 @@
 
 		{#if goldSponsors.length > 0}
 			<h3 class="mt-24 w-full text-left">{$_('sponsors.tiers.gold')}</h3>
-			<div class="grid md:grid-cols-3 items-center">
+			<div class="w-full grid md:grid-cols-3 items-center">
 				{#each goldSponsors as sponsor (sponsor.name)}
 					<a href={sponsor.link} target="_blank" rel="noopener" class="m-4">
 						<div class="block p-4 w-full">
@@ -179,7 +179,7 @@
 
 		{#if speakerEventSponsors.length > 0}
 			<h3 class="mt-24 w-full text-left">{$_('sponsors.tiers.speakerEvent')}</h3>
-			<div class="grid md:grid-cols-3 items-center">
+			<div class="w-full grid md:grid-cols-3 items-center">
 				{#each speakerEventSponsors as sponsor (sponsor.name)}
 					<a href={sponsor.link} target="_blank" rel="noopener" class="m-4">
 						<div class="block p-4 w-full">
@@ -192,7 +192,7 @@
 
 		{#if afterPartySponsors.length > 0}
 			<h3 class="mt-24 w-full text-left">{$_('sponsors.tiers.afterParty')}</h3>
-			<div class="grid md:grid-cols-3 items-center">
+			<div class="w-full grid md:grid-cols-3 items-center">
 				{#each afterPartySponsors as sponsor (sponsor.name)}
 					<a href={sponsor.link} target="_blank" rel="noopener" class="m-4">
 						<div class="block p-4 w-full">
@@ -205,7 +205,7 @@
 
 		{#if workshopSponsors.length > 0}
 			<h3 class="mt-24 w-full text-left">{$_('sponsors.tiers.workshop')}</h3>
-			<div class="grid md:grid-cols-4 items-center">
+			<div class="w-full grid md:grid-cols-4 items-center">
 				{#each workshopSponsors as sponsor (sponsor.name)}
 					<a href={sponsor.link} target="_blank" rel="noopener" class="m-4">
 						<div class="block p-4 w-full">
@@ -218,7 +218,7 @@
 
 		{#if silverSponsors.length > 0}
 			<h3 class="mt-24 w-full text-left">{$_('sponsors.tiers.silver')}</h3>
-			<div class="grid md:grid-cols-4 items-center">
+			<div class="w-full grid md:grid-cols-4 items-center">
 				{#each silverSponsors as sponsor (sponsor.name)}
 					<a href={sponsor.link} target="_blank" rel="noopener" class="m-4">
 						<div class="block p-4 w-full">
@@ -231,7 +231,7 @@
 
 		{#if bronzeSponsors.length > 0}
 			<h3 class="mt-24 w-full text-left">{$_('sponsors.tiers.bronze')}</h3>
-			<div class="grid md:grid-cols-6 items-center">
+			<div class="w-full grid md:grid-cols-6 items-center">
 				{#each bronzeSponsors as sponsor (sponsor.name)}
 					<a href={sponsor.link} target="_blank" rel="noopener" class="m-4">
 						<div class="block p-4 w-full">


### PR DESCRIPTION
Fixes #20 

Nesting `grid` within a `flex-column` or `flex` seems to be a problem on iPhone Safari. With this slightly altered layout for the speakers, we could avoid the issue.