### PR TITLE
Simulate external sessions using service sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
 				"svelte-check": "^3.0.1",
 				"svelte-fa": "^3.0.3",
 				"svelte-i18n": "^3.6.0",
+				"svelte-markdown": "^0.3.0",
 				"tailwindcss": "^3.3.2",
 				"tslib": "^2.4.1",
 				"typescript": "^5.0.0",
@@ -818,6 +819,12 @@
 			"version": "7.0.12",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
 			"integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+			"dev": true
+		},
+		"node_modules/@types/marked": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.1.tgz",
+			"integrity": "sha512-vSSbKZFbNktrQ15v7o1EaH78EbWV+sPQbPjHG+Cp8CaNcPFUEfjZ0Iml/V0bFDwsTlYe8o6XC5Hfdp91cqPV2g==",
 			"dev": true
 		},
 		"node_modules/@types/pug": {
@@ -2461,6 +2468,18 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/marked": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+			"dev": true,
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/mdn-data": {
 			"version": "2.0.30",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
@@ -3527,6 +3546,19 @@
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
 			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
 			"dev": true
+		},
+		"node_modules/svelte-markdown": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/svelte-markdown/-/svelte-markdown-0.3.0.tgz",
+			"integrity": "sha512-cFcHYZlykgCMxRp7fqPlaAGadp5dRiYjzpKTnf/yHMJo2ToUXwtL5h5krCVy03CC7fv096g4mD9SOTYjyOF5UA==",
+			"dev": true,
+			"dependencies": {
+				"@types/marked": "^4.0.1",
+				"marked": "^4.0.10"
+			},
+			"peerDependencies": {
+				"svelte": "^4.0.0"
+			}
 		},
 		"node_modules/svelte-preprocess": {
 			"version": "5.0.4",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"svelte-check": "^3.0.1",
 		"svelte-fa": "^3.0.3",
 		"svelte-i18n": "^3.6.0",
+		"svelte-markdown": "^0.3.0",
 		"tailwindcss": "^3.3.2",
 		"tslib": "^2.4.1",
 		"typescript": "^5.0.0",

--- a/src/lib/Session.ts
+++ b/src/lib/Session.ts
@@ -13,6 +13,10 @@ export enum SessionGroupName {
 
 export type GroupedSessions = Record<SessionGroupName, Session[]>;
 
+export interface Event {
+	sessions: Session[];
+}
+
 export interface SessionGroup {
 	groupId: string;
 	groupName: SessionGroupName;
@@ -50,18 +54,24 @@ interface SessionCategory {
 }
 
 export function sessionLogo(session: Session) {
-	for (const c of session.categories) {
-		if (c.name === 'Logo') {
-			for (const i of c.categoryItems) {
-				switch (i.name) {
-					case 'Kubernetes':
-						return kubernetes;
-					case 'Argo CD':
-						return argoCD;
-					case 'Backstage':
-						return backstage;
+	if (session.categories) {
+		for (const c of session.categories) {
+			if (c.name === 'Logo') {
+				for (const i of c.categoryItems) {
+					switch (i.name) {
+						case 'Kubernetes':
+							return kubernetes;
+						case 'Argo CD':
+							return argoCD;
+						case 'Backstage':
+							return backstage;
+					}
 				}
 			}
 		}
 	}
+}
+
+export function isExternalSession(session: Session) {
+	return session.isServiceSession && session.title.indexOf('hosted by') >= 0;
 }

--- a/src/routes/schedule/+page.svelte
+++ b/src/routes/schedule/+page.svelte
@@ -3,7 +3,10 @@
 	import type { PageData } from './$types';
 	import ServiceSession from './ServiceSession.svelte';
 	import TrackSession from './TrackSession.svelte';
+	import ExternalSession from './ExternalSession.svelte';
 	import type { Session } from '$lib/Session';
+	import { isExternalSession } from '$lib/Session';
+	import type { ScheduleDate } from '$lib/Schedule';
 
 	export let data: PageData;
 	export let schedule = data.schedule;
@@ -13,7 +16,10 @@
 		const startTime = session.startsAt || '';
 		const durationMillis = new Date(endTime).getTime() - new Date(startTime).getTime();
 		const durationMinutes = Math.round(durationMillis / 60000);
-		if (durationMinutes <= 15) {
+		if (isExternalSession(session)) {
+			return 'h-28';
+		}
+		else if (durationMinutes <= 15) {
 			return 'h-20';
 		} else if (15 < durationMinutes && durationMinutes <= 30) {
 			return 'h-28';
@@ -26,6 +32,50 @@
 		}
 	};
 
+	/**
+	 * Returns the appropriate md:col-span- class for a session.
+	 * Tailwind needs the class names to be present in the code verbatim, in order for the build
+	 * to include them in the css. Hence, we cannot use string interpolation
+	 * (e.g. md:col-span-{ ( sesion.isPlenumSession ? ... : ...) }).
+	 *
+	 * @param session - a session
+	 */
+	const getSessionWidth = (session: Session) => {
+		if (session.isPlenumSession) {
+			return 'md:col-span-full';
+		}
+		else {
+			return 'md:col-span-1';
+		}
+	}
+
+	/**
+	 * Returns the appropriate md:grid-cols- class for the number of tracks in a day of the schedule.
+	 * Tailwind needs the class names to be present in the code verbatim, in order for the build
+	 * to include them in the css. Hence, we cannot use string interpolation (e.g. md:grid-cols-{length}).
+	 *
+	 * @param scheduleDate - a schedule day
+	 */
+	const getNumberOfTracks = (scheduleDate: ScheduleDate) => {
+		switch (scheduleDate.rooms.length) {
+			case 1:
+				return 'md:grid-cols-1';
+			case 2:
+				return 'md:grid-cols-2';
+			case 3:
+				return 'md:grid-cols-3';
+			case 4:
+				return 'md:grid-cols-4';
+			case 5:
+				return 'md:grid-cols-5';
+			case 6:
+				return 'md:grid-cols-6';
+			default:
+				return 'md:grid-cols-1';
+		}
+	}
+
+
 	const getDateString = (
 		json: (id: string, locale?: string | undefined) => unknown,
 		index: number
@@ -33,6 +83,7 @@
 		let dateStrings = json('schedule.dates') as string[];
 		return dateStrings[index];
 	};
+
 </script>
 
 <div class="bg-slate-100 w-full px-8 py-8">
@@ -40,16 +91,22 @@
 		<section class="container mx-auto items-center text-center max-w-5xl">
 			<h2 class="m-8">{getDateString($json, index)}</h2>
 			{#each scheduleDate.timeSlots as timeSlot (timeSlot.slotStart)}
-				<div class="grid md:grid-cols-{scheduleDate.rooms.length} gap-2">
+				<div class="grid {getNumberOfTracks(scheduleDate)} gap-2">
 					{#each timeSlot.rooms as room (room.id)}
-						{#if room.session.isServiceSession}
+						{#if isExternalSession(room.session)}
+							<ExternalSession
+								{room}
+								{getSessionWidth}
+								{getSessionHeight}
+							/>
+						{:else if room.session.isServiceSession}
 							<ServiceSession
 								{room}
-								totalRoomNumber={scheduleDate.rooms.length}
+								{getSessionWidth}
 								{getSessionHeight}
 							/>
 						{:else}
-							<TrackSession {room} totalRoomNumber={scheduleDate.rooms.length} {getSessionHeight} />
+							<TrackSession {room} {getSessionWidth} {getSessionHeight} />
 						{/if}
 					{/each}
 				</div>

--- a/src/routes/schedule/ExternalSession.svelte
+++ b/src/routes/schedule/ExternalSession.svelte
@@ -3,8 +3,8 @@
 	import type { Session } from '$lib/Session';
 
 	export let room: TimeSlotRoom;
-	export let getSessionWidth: (session: Session) => string;
 	export let getSessionHeight: (session: Session) => string;
+	export let getSessionWidth: (session: Session) => string;
 	const startTime = room.session.startsAt || '';
 	const endTime = room.session.endsAt || '';
 	const extractTime = (dateString: string) =>
@@ -12,22 +12,16 @@
 </script>
 
 <div
-	class="card variant-soft-primary {getSessionWidth(room.session)} p-2 mb-2 {getSessionHeight(room.session)}"
+	class="card variant-soft-secondary {getSessionWidth(room.session)} mb-2 {getSessionHeight(room.session)}"
 >
 	<header class="card-header flex justify-center">
 		<h4>
 			<a href="/sessions/{room.session.id}" style="text-decoration: none;">{room.session.title}</a>
 		</h4>
 	</header>
-	{#each room.session.speakers as speaker (speaker.id)}
-		<section class="flex justify-center">
-			<a href="/speakers/{speaker.id}" style="text-decoration: none;">{speaker.name}</a>
-		</section>
-	{/each}
 	<section class="flex justify-center">
 		{#if startTime != '' && endTime != ''}
 			{extractTime(startTime)} - {extractTime(endTime)}
 		{/if}
-		{room.name}
 	</section>
 </div>

--- a/src/routes/schedule/ServiceSession.svelte
+++ b/src/routes/schedule/ServiceSession.svelte
@@ -3,7 +3,7 @@
 	import type { Session } from '$lib/Session';
 
 	export let room: TimeSlotRoom;
-	export let totalRoomNumber: number;
+	export let getSessionWidth: (session: Session) => string;
 	export let getSessionHeight: (session: Session) => string;
 	const startTime = room.session.startsAt || '';
 	const endTime = room.session.endsAt || '';
@@ -14,9 +14,7 @@
 </script>
 
 <div
-	class="card variant-soft-secondary md:col-span-{room.session.isPlenumSession
-		? totalRoomNumber
-		: 1} mb-2 {getSessionHeight(room.session)}"
+	class="card variant-soft-secondary {getSessionWidth(room.session)} mb-2 {getSessionHeight(room.session)}"
 >
 	<header class="card-header flex justify-center">
 		<h4>{room.session.title}</h4>

--- a/src/routes/sessions/[id]/+page.svelte
+++ b/src/routes/sessions/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types';
-	import { sessionLogo } from '$lib/Session';
+	import { isExternalSession, sessionLogo } from '$lib/Session';
+	import SvelteMarkdown from 'svelte-markdown';
 
 	export let data: PageData;
 
@@ -15,7 +16,11 @@
 			{/if}
 			<h1>{data.session.title}</h1>
 			<h4 class="mt-4">{data.session.speakers.map((s) => s.name).join(', ')}</h4>
-			<p class="my-12 whitespace-pre-wrap">{data.session.description}</p>
+			{#if isExternalSession(data.session)}
+				<p class="my-12 whitespace-pre-wrap"><SvelteMarkdown source={data.session.description || ""} /></p>
+			{:else}
+				<p class="my-12 whitespace-pre-wrap">{data.session.description}</p>
+			{/if}
 		</div>
 	</section>
 </div>


### PR DESCRIPTION
We want to include a shout-out to a meetup by Guild42 in our schedule. The approach works as follows:

- use a service session in Sessionize
- detect an external session via the string `hosted by` in the title of the service session
- allow the external sessions to have markdown in their description in order to enable linking to the external party's event
- do not interpret the description of other sessions as markdown, in order not to break their current formatting.

When implementing this, I also fixed an issue with interpolated class names and the Tailwind CSS build.